### PR TITLE
Dist task now copies src/*.d.ts files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,16 @@
 module.exports = function (grunt) {
+	const distTasks = [
+		'clean:typings',
+		'typings',
+		'tslint',
+		'clean:dist',
+		'ts:dist',
+		'fixSourceMaps',
+		'copy:staticDefinitionFiles'
+	];
+
 	require('grunt-dojo2').initConfig(grunt, {
-		/* any custom configuration goes here */
+		distTasks
 	});
 
 	function setCombined(combined) {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "dojo-has": ">=2.0.0-alpha",
     "dojo-loader": ">=2.0.0-beta.7",
     "grunt": "~1.0.1",
-    "grunt-dojo2": "2.0.0-beta.16",
+    "grunt-dojo2": ">=2.0.0-beta.19",
     "intern": "^3.2.3",
     "tslint": "^3.11.0",
     "typescript": "~2.0.3"


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR actually fully resolves #1, even though it is already closed.  It copies the `/src/**/*.d.ts` files to the distribution directory on `grunt dist` which means that package can actually be properly published on npm as `dojo-interfaces`.

Resolves #1
