### PR TITLE
Allow Evented#emit(event) to be a superset of EventedObject

### DIFF
--- a/src/bases.d.ts
+++ b/src/bases.d.ts
@@ -40,7 +40,7 @@ export interface Evented extends Destroyable {
 	 *
 	 * @param event The `EventTargettedObject` to be delivered to listeners based on `event.type`
 	 */
-	emit(event: EventObject): void;
+	emit<E extends EventObject>(event: E): void;
 
 	/**
 	 * Attach a map to events *types* specified by the key of the map and the value being the *listener* or


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

The following now works:

```ts
evented.emit({
    type: 'foo',
    target: event
});
```

Where previously passing an object literal on emit would have caused a type error.

Resolves #23

