### PR TITLE
Add generic for target type in event object

### DIFF
--- a/src/bases.d.ts
+++ b/src/bases.d.ts
@@ -110,7 +110,7 @@ export interface State {
 	[key: string]: any;
 }
 
-export interface StateChangeEvent<S> extends EventTypedObject<'state:changed'> {
+export interface StateChangeEvent<S, T extends Stateful<S>> extends EventTypedObject<'state:changed'> {
 	/**
 	 * The state of the target
 	 */
@@ -119,7 +119,7 @@ export interface StateChangeEvent<S> extends EventTypedObject<'state:changed'> {
 	/**
 	 * A Stateful instance
 	 */
-	target: Stateful<S>;
+	target: T;
 }
 
 export interface StateInitalizedEvent<S> extends EventTypedObject<'state:initialized'> {
@@ -141,7 +141,7 @@ export type Stateful<S extends State> = StatefulMixin<S> & Evented & {
 	 * @param type The event type to listen for
 	 * @param listener The listener that will be called when the event occurs
 	 */
-	on(type: 'state:changed', listener: EventedListener<Stateful<S>, StateChangeEvent<S>>): Handle;
+	on(type: 'state:changed', listener: EventedListener<Stateful<S>, StateChangeEvent<S, Stateful<S>>>): Handle;
 
 	/**
 	 * Add a listener for a `state:completed` event, which occurs when state is observed

--- a/src/bases.d.ts
+++ b/src/bases.d.ts
@@ -122,7 +122,7 @@ export interface StateChangeEvent<S, T extends Stateful<S>> extends EventTypedOb
 	target: T;
 }
 
-export interface StateInitalizedEvent<S> extends EventTypedObject<'state:initialized'> {
+export interface StateInitalizedEvent<S, T extends Stateful<S>> extends EventTypedObject<'state:initialized'> {
 	/**
 	 * The state of the target
 	 */
@@ -131,7 +131,7 @@ export interface StateInitalizedEvent<S> extends EventTypedObject<'state:initial
 	/**
 	 * A Stateful instance
 	 */
-	target: Stateful<S>;
+	target: T;
 }
 
 export type Stateful<S extends State> = StatefulMixin<S> & Evented & {
@@ -161,7 +161,7 @@ export type Stateful<S extends State> = StatefulMixin<S> & Evented & {
 	 * @param type The event type to listen for
 	 * @param listener The listener that will be called when the event occurs
 	 */
-	on(type: 'state:initialized', listener: EventedListener<Stateful<S>, StateInitalizedEvent<S>>): Handle;
+	on(type: 'state:initialized', listener: EventedListener<Stateful<S>, StateInitalizedEvent<S, Stateful<S>>>): Handle;
 }
 
 export interface StatefulMixin<S extends State>{

--- a/tests/unit/bases.ts
+++ b/tests/unit/bases.ts
@@ -14,7 +14,7 @@ registerSuite({
 		assertType.isType(basesTypes, 'EventedCallback', 'EventedCallback<E>');
 		assertType.isType(basesTypes, 'EventedListenersMap', 'EventedListenersMap<T>');
 		assertType.isType(basesTypes, 'EventedListenerOrArray', 'EventedListenerOrArray<T, E>');
-		assertType.isType(basesTypes, 'StateChangeEvent', 'StateChangeEvent<S>');
+		assertType.isType(basesTypes, 'StateChangeEvent', 'StateChangeEvent<S, T>');
 		assertType.isType(basesTypes, 'StateInitalizedEvent', 'StateInitalizedEvent<S>');
 		assertType.isType(basesTypes, 'Stateful', 'Stateful<S>');
 		assertType.isType(basesTypes, 'StatefulMixin', 'StatefulMixin<S>');

--- a/tests/unit/bases.ts
+++ b/tests/unit/bases.ts
@@ -15,7 +15,7 @@ registerSuite({
 		assertType.isType(basesTypes, 'EventedListenersMap', 'EventedListenersMap<T>');
 		assertType.isType(basesTypes, 'EventedListenerOrArray', 'EventedListenerOrArray<T, E>');
 		assertType.isType(basesTypes, 'StateChangeEvent', 'StateChangeEvent<S, T>');
-		assertType.isType(basesTypes, 'StateInitalizedEvent', 'StateInitalizedEvent<S>');
+		assertType.isType(basesTypes, 'StateInitalizedEvent', 'StateInitalizedEvent<S, T>');
 		assertType.isType(basesTypes, 'Stateful', 'Stateful<S>');
 		assertType.isType(basesTypes, 'StatefulMixin', 'StatefulMixin<S>');
 		assertType.isType(basesTypes, 'StatefulOptions', 'StatefulOptions<S>');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Enhance typings to support generics for the target type of an event

Resolves #25 

