### PR TITLE
Add generics for the target type on events

### DIFF
--- a/src/bases.d.ts
+++ b/src/bases.d.ts
@@ -58,7 +58,7 @@ export interface Evented extends Destroyable {
 	 * @param listener A listener or array of listeners that accept error events
 	 * @returns A handle which can be used to remove the listeners
 	 */
-	on<T>(type: 'error', listener: EventedListenerOrArray<T, EventErrorObject<T>>): Handle;
+	on<T extends Evented>(type: 'error', listener: EventedListenerOrArray<T, EventErrorObject<T>>): Handle;
 
 	/**
 	 * Attach a `listener` to a particular event `type`.

--- a/src/bases.d.ts
+++ b/src/bases.d.ts
@@ -49,7 +49,7 @@ export interface Evented extends Destroyable {
 	 * @param listeners An object which contains key value pairs of event types and listeners.
 	 * @returns A handle which can be used to remove the listeners
 	 */
-	on(listeners: EventedListenersMap<this>): Handle;
+	on<T>(listeners: EventedListenersMap<T>): Handle;
 
 	/**
 	 * Attach a listener (or array of listeners) to an `error` event.
@@ -58,7 +58,7 @@ export interface Evented extends Destroyable {
 	 * @param listener A listener or array of listeners that accept error events
 	 * @returns A handle which can be used to remove the listeners
 	 */
-	on(type: 'error', listener: EventedListenerOrArray<this, EventErrorObject<this>>): Handle;
+	on<T>(type: 'error', listener: EventedListenerOrArray<T, EventErrorObject<T>>): Handle;
 
 	/**
 	 * Attach a `listener` to a particular event `type`.
@@ -68,7 +68,7 @@ export interface Evented extends Destroyable {
 	 *                 or an array of of such listeners.
 	 * @returns A handle which can be used to remove the listener
 	 */
-	on(type: string, listener: EventedListenerOrArray<this, EventTargettedObject<this>>): Handle;
+	on<T>(type: string, listener: EventedListenerOrArray<T, EventTargettedObject<T>>): Handle;
 }
 
 /**


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Allow type to be passed for the target for `Evented#on`

Resolves #27

