### PR TITLE
Add interfaces for `d` and remove `CompositeWidget`

### DIFF
--- a/src/widgetBases.d.ts
+++ b/src/widgetBases.d.ts
@@ -26,7 +26,7 @@ import { VNode, VNodeProperties } from './vdom';
  * TODO: Should this behave more like a reducer (like above)?
  */
 export interface ChildNodeFunction {
-	(this: Widget<WidgetState>): DWrapper[] | VNode[];
+	(this: Widget<WidgetState>): DNode[] | VNode[];
 }
 
 /**
@@ -222,11 +222,11 @@ export interface SubWidgetManager<W extends Renderable> {
 	readonly size: number;
 }
 
-export interface VWrapper {
+export interface HNode {
 	/**
 	 * Specified children
 	 */
-	children: (VNode | DWrapper)[];
+	children: (VNode | DNode)[];
 
 	/**
 	 * render function that wraps returns VNode
@@ -234,7 +234,7 @@ export interface VWrapper {
 	render(): VNode;
 }
 
-export interface WWrapper {
+export interface WNode {
 	/**
 	 * Factory to create a widget
 	 */
@@ -246,7 +246,7 @@ export interface WWrapper {
 	options: WidgetOptions<WidgetState>;
 }
 
-export type DWrapper = VWrapper | WWrapper;
+export type DNode = HNode | WNode;
 
 export type Widget<S extends WidgetState> = Stateful<S> & WidgetMixin & WidgetOverloads;
 
@@ -268,16 +268,6 @@ export interface WidgetMixin {
 	 * method.
 	 */
 	childNodeRenderers: ChildNodeFunction[];
-
-	/**
-	 * Accepts a DWrapper object and returns the approproate VNode
-	 */
-	getVNode(child: DWrapper): VNode;
-
-	/**
-	 * Prune empty children and manage them accordingly
-	 */
-	pruneChildren(): void;
 
 	/**
 	 * Classes which are applied upon render.

--- a/src/widgetBases.d.ts
+++ b/src/widgetBases.d.ts
@@ -26,14 +26,7 @@ import { VNode, VNodeProperties } from './vdom';
  * TODO: Should this behave more like a reducer (like above)?
  */
 export interface ChildNodeFunction {
-	(this: Widget<WidgetState>, childrenNodes: (VNode | string)[]): (VNode | string)[];
-}
-
-/**
- * A function that is called when collecting all the DWrappers to render within a composite widget.
- */
-export interface DWrapperFunction {
-	(this: CompositeWidget<WidgetState>): DWrapper[];
+	(this: Widget<WidgetState>): DWrapper[] | VNode[];
 }
 
 /**
@@ -255,11 +248,26 @@ export interface WWrapper {
 
 export type DWrapper = VWrapper | WWrapper;
 
-export interface CompositeMixin {
+export type Widget<S extends WidgetState> = Stateful<S> & WidgetMixin & WidgetOverloads;
+
+export interface WidgetOverloads {
 	/**
-	 * Array of functions that return children as DWrappers
+	 * Attach a listener to the invalidated event, which is emitted when the `.invalidate()` method is called
+	 *
+	 * @param type The event type to listen for
+	 * @param listener The listener to call when the event is emitted
 	 */
-	children: DWrapperFunction[];
+	on(type: 'invalidated', listener: EventedListener<Widget<WidgetState>, EventTargettedObject<Widget<WidgetState>>>): Handle;
+}
+
+export interface WidgetMixin {
+	/**
+	 * An array of child node render functions which are executed on a render to generate the children
+	 * nodes.  These are intended to be "static" and bound to the class, making it easy for mixins to
+	 * alter the behaviour of the render process without needing to override or aspect the `getChildrenNodes`
+	 * method.
+	 */
+	childNodeRenderers: ChildNodeFunction[];
 
 	/**
 	 * Accepts a DWrapper object and returns the approproate VNode
@@ -270,23 +278,6 @@ export interface CompositeMixin {
 	 * Prune empty children and manage them accordingly
 	 */
 	pruneChildren(): void;
-}
-
-/**
- * The *final* type for the CompositeWidget
- */
-export type CompositeWidget<S extends WidgetState> = Widget<S> & CompositeMixin;
-
-export type Widget<S extends WidgetState> = Stateful<S> & WidgetMixin;
-
-export interface WidgetMixin {
-	/**
-	 * An array of child node render functions which are executed on a render to generate the children
-	 * nodes.  These are intended to be "static" and bound to the class, making it easy for mixins to
-	 * alter the behaviour of the render process without needing to override or aspect the `getChildrenNodes`
-	 * method.
-	 */
-	childNodeRenderers: ChildNodeFunction[];
 
 	/**
 	 * Classes which are applied upon render.
@@ -333,14 +324,6 @@ export interface WidgetMixin {
 	 * the `getNodeAttributes` method.
 	 */
 	nodeAttributes: NodeAttributeFunction[];
-
-	/**
-	 * Attach a listener to the invalidated event, which is emitted when the `.invalidate()` method is called
-	 *
-	 * @param type The event type to listen for
-	 * @param listener The listener to call when the event is emitted
-	 */
-	on(type: 'invalidated', listener: EventedListener<Widget<WidgetState>, EventTargettedObject<Widget<WidgetState>>>): Handle;
 
 	/**
 	 * Render the widget, returing the virtual DOM node that represents this widget.

--- a/src/widgetBases.d.ts
+++ b/src/widgetBases.d.ts
@@ -283,7 +283,7 @@ export interface WidgetMixin {
 	 * Mixins should not override or aspect this method, but instead provide a function as part of the
 	 * `childNodeRenders` property, which will automatically get called by this method upon render.
 	 */
-	getChildrenNodes(): (VNode | string)[];
+	getChildrenNodes(): (VNode | DNode)[];
 
 	/**
 	 * Generate the node attributes when rendering the widget.

--- a/tests/unit/widgetBases.ts
+++ b/tests/unit/widgetBases.ts
@@ -14,8 +14,6 @@ registerSuite({
 		assertType.isType(widgetBasesTypes, 'VWrapper', 'VWrapper');
 		assertType.isType(widgetBasesTypes, 'WWrapper', 'WWrapper');
 		assertType.isType(widgetBasesTypes, 'DWrapper', 'DWrapper');
-		assertType.isType(widgetBasesTypes, 'CompositeMixin', 'CompositeMixin');
-		assertType.isType(widgetBasesTypes, 'CompositeWidget', 'CompositeWidget<S>');
 		assertType.isType(widgetBasesTypes, 'ContainerWidgetMixin', 'ContainerWidgetMixin<C>');
 		assertType.isType(widgetBasesTypes, 'ContainerWidget', 'ContainerWidget<C, S>');
 		assertType.isType(widgetBasesTypes, 'ContainerWidgetOptions', 'ContainerWidgetOptions<C, S>');

--- a/tests/unit/widgetBases.ts
+++ b/tests/unit/widgetBases.ts
@@ -11,9 +11,9 @@ registerSuite({
 		assertType.isType(widgetBasesTypes, 'ChildNodeFunction', 'ChildNodeFunction');
 		assertType.isType(widgetBasesTypes, 'NodeAttributeFunction', 'NodeAttributeFunction');
 		assertType.isType(widgetBasesTypes, 'ChildrenChangeEvent', 'ChildrenChangeEvent<T>');
-		assertType.isType(widgetBasesTypes, 'VWrapper', 'VWrapper');
-		assertType.isType(widgetBasesTypes, 'WWrapper', 'WWrapper');
-		assertType.isType(widgetBasesTypes, 'DWrapper', 'DWrapper');
+		assertType.isType(widgetBasesTypes, 'HNode', 'HNode');
+		assertType.isType(widgetBasesTypes, 'WNode', 'WNode');
+		assertType.isType(widgetBasesTypes, 'DNode', 'DNode');
 		assertType.isType(widgetBasesTypes, 'ContainerWidgetMixin', 'ContainerWidgetMixin<C>');
 		assertType.isType(widgetBasesTypes, 'ContainerWidget', 'ContainerWidget<C, S>');
 		assertType.isType(widgetBasesTypes, 'ContainerWidgetOptions', 'ContainerWidgetOptions<C, S>');

--- a/tests/unit/widgetBases.ts
+++ b/tests/unit/widgetBases.ts
@@ -11,9 +11,11 @@ registerSuite({
 		assertType.isType(widgetBasesTypes, 'ChildNodeFunction', 'ChildNodeFunction');
 		assertType.isType(widgetBasesTypes, 'NodeAttributeFunction', 'NodeAttributeFunction');
 		assertType.isType(widgetBasesTypes, 'ChildrenChangeEvent', 'ChildrenChangeEvent<T>');
-		assertType.isType(widgetBasesTypes, 'CompositeManagerFunction', 'CompositeManagerFunction<W, S>');
-		assertType.isType(widgetBasesTypes, 'CompositeMixin', 'CompositeMixin<W, S>');
-		assertType.isType(widgetBasesTypes, 'CompositeWidget', 'CompositeWidget<W, S>');
+		assertType.isType(widgetBasesTypes, 'VWrapper', 'VWrapper');
+		assertType.isType(widgetBasesTypes, 'WWrapper', 'WWrapper');
+		assertType.isType(widgetBasesTypes, 'DWrapper', 'DWrapper');
+		assertType.isType(widgetBasesTypes, 'CompositeMixin', 'CompositeMixin');
+		assertType.isType(widgetBasesTypes, 'CompositeWidget', 'CompositeWidget<S>');
 		assertType.isType(widgetBasesTypes, 'ContainerWidgetMixin', 'ContainerWidgetMixin<C>');
 		assertType.isType(widgetBasesTypes, 'ContainerWidget', 'ContainerWidget<C, S>');
 		assertType.isType(widgetBasesTypes, 'ContainerWidgetOptions', 'ContainerWidgetOptions<C, S>');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add supporting interfaces and `CompositeWidget` interface inline with `d` proposal.

Resolves #28 
Resolves #29 
