### PR TITLE
Allow null entries in the children array of HNodes

### DIFF
--- a/src/widgetBases.d.ts
+++ b/src/widgetBases.d.ts
@@ -226,7 +226,7 @@ export interface HNode {
 	/**
 	 * Specified children
 	 */
-	children: (VNode | DNode)[];
+	children: (VNode | DNode | null)[];
 
 	/**
 	 * render function that wraps returns VNode


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Extend `HNode` interface to allow `children` array to contain `null` entries, this will allow consumers to express logic in children such as 

```ts
return [
    d('div', {}, [
        this.state.active ? d('div.active') : null
    ])
]
```

returning `null` when the widget is not required for the current render.

Related: https://github.com/dojo/widgets/issues/93

