### PR TITLE
Add registry interfaces to abilities

### DIFF
--- a/src/abilities.d.ts
+++ b/src/abilities.d.ts
@@ -8,7 +8,7 @@
 import Promise from 'dojo-shim/Promise';
 import Map from 'dojo-shim/Map';
 import { Destroyable, EventedListener } from './bases';
-import { EventTargettedObject, Handle } from './core';
+import { EventTargettedObject, Factory, Handle } from './core';
 import { Observable } from './observables';
 import { VNode } from './vdom';
 
@@ -34,6 +34,47 @@ export interface ActionableOptions<T, E extends EventTargettedObject<T>> {
 	 * An event object
 	 */
 	event: E;
+}
+
+export interface CreatableRegistry<T> extends IdentifiableRegistry<T> {
+	/**
+	 * Realize a child of the specified parent, returning a promise which resolves with
+	 * a tuple that contains the ID and the realized instance.
+	 *
+	 * @param parent The parent where the realized child should be attached to
+	 * @param factory The factory that should be used to realize the child
+	 * @param options Any options that should be passed to the factory when realizing the child
+	 */
+	create<U extends T, O>(factory: Factory<U, O>, options?: O): Promise<[ string, U ]>;
+}
+
+export interface IdentifiableRegistry<T> {
+	/**
+	 * Asynchronously get an instance by its ID.
+	 *
+	 * @param id Identifier for the instance that is to be retrieved
+	 * @return A promise for the instance. The promise rejects if no instance was found.
+	 */
+	get(id: string | symbol): Promise<T>;
+
+	/**
+	 * Check if the registry constains a widget with the identifier provided.
+	 *
+	 * @param id Identifier for the instance to check whether exists in the registry.
+	 * @return A promise for the result of the has check. The promise resolves to `true` if
+	 *         an instance is found and `false` otherwise.
+	 */
+	has(id: string | symbol): Promise<boolean>;
+
+	/**
+	 * Look up the identifier for which the given value has been registered.
+	 *
+	 * Throws if the value hasn't been registered.
+	 *
+	 * @param value The value to determine the identity for
+	 * @return The identifier
+	 */
+	identify(value: T): string | symbol;
 }
 
 export interface Invalidatable {

--- a/src/widgetBases.d.ts
+++ b/src/widgetBases.d.ts
@@ -14,7 +14,7 @@
 
 import Promise from 'dojo-shim/Promise';
 import Map from 'dojo-shim/Map';
-import { Renderable, RenderableParent } from './abilities';
+import { CreatableRegistry, Renderable, RenderableParent } from './abilities';
 import { EventedListener, State, Stateful, StatefulOptions } from './bases';
 import { EventTargettedObject, Factory, Handle, StylesMap } from './core';
 import { VNode, VNodeProperties } from './vdom';
@@ -128,6 +128,12 @@ export interface ContainerWidgetOptions<C extends Renderable, S extends Containe
 	 * A list of children to be created and added to the container at creation time
 	 */
 	createChildren?: CreateWidgetList<C, WidgetOptions<WidgetState>> | CreateWidgetMap<C, WidgetOptions<WidgetState>>;
+
+	/**
+	 * A registry provider (like `dojo-app`) which offers a registry f type `widget` so that children of the container
+	 * can be identified and registered.
+	 */
+	registryProvider?: { get(type: 'widgets'): CreatableRegistry<Renderable>; };
 
 	/**
 	 * Provide a sort function for this instance which will sort the children renders at render time

--- a/tests/unit/abilities.ts
+++ b/tests/unit/abilities.ts
@@ -10,6 +10,8 @@ registerSuite({
 		const abilitiesTypes = types[file];
 		assertType.isType(abilitiesTypes, 'Actionable', 'Actionable<T, E>');
 		assertType.isType(abilitiesTypes, 'ActionableOptions', 'ActionableOptions<T, E>');
+		assertType.isType(abilitiesTypes, 'CreatableRegistry', 'CreatableRegistry<T>');
+		assertType.isType(abilitiesTypes, 'IdentifiableRegistry', 'IdentifiableRegistry<T>');
 		assertType.isType(abilitiesTypes, 'Invalidatable', 'Invalidatable');
 		assertType.isType(abilitiesTypes, 'Renderable', 'Renderable');
 		assertType.isType(abilitiesTypes, 'RenderableParent', 'RenderableParent');


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Add `CreateableRegistry` and `IdentifiableRegistry` to `abilities.d.ts`

Resolves #38

