### PR TITLE
Support 'getNode' in widget mixin

### DIFF
--- a/src/widgetBases.d.ts
+++ b/src/widgetBases.d.ts
@@ -19,7 +19,7 @@ import { EventTargettedObject, Factory, Handle, StylesMap } from './core';
 import { VNode, VNodeProperties } from './vdom';
 
 /**
- * A function that is called when collecting the children nodes on render.
+ * A function that is called to return top level node
  */
 export interface NodeFunction {
 	(this: Widget<WidgetState>): VNode;

--- a/src/widgetBases.d.ts
+++ b/src/widgetBases.d.ts
@@ -21,6 +21,13 @@ import { VNode, VNodeProperties } from './vdom';
 /**
  * A function that is called when collecting the children nodes on render.
  */
+export interface NodeFunction {
+	(this: Widget<WidgetState>): VNode | string[];
+}
+
+/**
+ * A function that is called when collecting the children nodes on render.
+ */
 export interface ChildNodeFunction {
 	(this: Widget<WidgetState>): DNode[] | VNode[];
 }
@@ -266,6 +273,11 @@ export interface WidgetMixin {
 	 * stored in the instances state object.
 	 */
 	readonly classes: string[];
+
+	/**
+	 * Get the top level node and children when rendering the widget.
+	 */
+	getNode: NodeFunction;
 
 	/**
 	 * Generate the children nodes when rendering the widget.

--- a/src/widgetBases.d.ts
+++ b/src/widgetBases.d.ts
@@ -22,7 +22,7 @@ import { VNode, VNodeProperties } from './vdom';
  * A function that is called when collecting the children nodes on render.
  */
 export interface NodeFunction {
-	(this: Widget<WidgetState>): VNode | string[];
+	(this: Widget<WidgetState>): VNode;
 }
 
 /**

--- a/src/widgetBases.d.ts
+++ b/src/widgetBases.d.ts
@@ -22,7 +22,7 @@ import { VNode, VNodeProperties } from './vdom';
  * A function that is called to return top level node
  */
 export interface NodeFunction {
-	(this: Widget<WidgetState>): VNode;
+	(this: Widget<WidgetState>): DNode;
 }
 
 /**


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Create API to return the top level node of a widget

References: https://github.com/dojo/widgets/issues/144

