### PR TITLE
Support children for widgets

### DIFF
--- a/src/widgetBases.d.ts
+++ b/src/widgetBases.d.ts
@@ -242,6 +242,11 @@ export interface WNode {
 	 * Options used to create factory a widget
 	 */
 	options: WidgetOptions<WidgetState>;
+
+	/**
+	 * DNode children
+	 */
+	children: DNode[];
 }
 
 export type DNode = HNode | WNode | string;
@@ -266,6 +271,11 @@ export interface WidgetMixin {
 	 * stored in the instances state object.
 	 */
 	readonly classes: string[];
+
+	/**
+	 * An array of children `DNode`s returned via `getChildrenNodes`
+	 */
+	children: DNode[];
 
 	/**
 	 * Generate the children nodes when rendering the widget.


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Support an array of `DNode`s as children for the factory `d` API

References: https://github.com/dojo/widgets/issues/145