### PR TITLE
Update `state` and `setState` use 'Partial' type

### DIFF
--- a/src/bases.d.ts
+++ b/src/bases.d.ts
@@ -106,10 +106,6 @@ export interface EventedListenersMap<T> {
  */
 export type EventedListenerOrArray<T, E extends EventTargettedObject<T>> = EventedListener<T, E> | EventedListener<T, E>[];
 
-export interface State {
-	[key: string]: any;
-}
-
 export interface StateChangeEvent<S, T extends Stateful<S>> extends EventTypedObject<'state:changed'> {
 	/**
 	 * The state of the target
@@ -134,7 +130,7 @@ export interface StateInitalizedEvent<S, T extends Stateful<S>> extends EventTyp
 	target: T;
 }
 
-export type Stateful<S extends State> = StatefulMixin<S> & Evented & {
+export type Stateful<S> = StatefulMixin<S> & Evented & {
 	/**
 	 * Add a listener for a `state:changed` event, which occurs whenever the state changes on the instance.
 	 *
@@ -164,11 +160,11 @@ export type Stateful<S extends State> = StatefulMixin<S> & Evented & {
 	on(type: 'state:initialized', listener: EventedListener<Stateful<S>, StateInitalizedEvent<S, Stateful<S>>>): Handle;
 }
 
-export interface StatefulMixin<S extends State>{
+export interface StatefulMixin<S> {
 	/**
-	 * A read only view of the state
+	 * A state of the instannce
 	 */
-	readonly state: S;
+	readonly state: Partial<S>;
 
 	/**
 	 * A readonly reference to the stateFrom provided to the widget on instantiation.
@@ -183,7 +179,7 @@ export interface StatefulMixin<S extends State>{
 	 *
 	 * @param value The state (potentially partial) to be set
 	 */
-	setState(value: S): void;
+	setState(state: Partial<S>): void;
 
 	/**
 	 * Observe (and update) the state from an Observable
@@ -194,8 +190,18 @@ export interface StatefulMixin<S extends State>{
 	observeState(id: string, observable: StoreObservablePatchable<S>): Handle;
 }
 
-export interface StatefulOptions<S extends State> extends EventedOptions {
+/**
+ * Options for a stateful object
+ */
+export interface StatefulOptions<S> extends EventedOptions {
+
+	/**
+	 * id of the stateful object when using `StoreObservablePatchable`.
+	 */
 	id?: string;
-	state?: S;
+
+	/**
+	 * The `StoreObservablePatchable` used to back state.
+	 */
 	stateFrom?: StoreObservablePatchable<S>;
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Make `state` a `Partial` on the `StatefulMixin`, remove `state` from options and convert `setState` to property setter.

For support of https://github.com/dojo/widgets/issues/176