### PR TITLE
Expose get in `StoreObservable` and rename interfaces for consistency.

### DIFF
--- a/src/abilities.d.ts
+++ b/src/abilities.d.ts
@@ -84,17 +84,23 @@ export interface RenderableParent extends Renderable {
 	readonly children: Map<string, Renderable>;
 }
 
-export interface StoreObservable<T> {
+export interface ObservableStore<T> {
 	/**
 	 * A method that allows the return of an `Observable` interface for a particular `id`
 	 * @param id The ID to observe
 	 */
 	observe(id: string): Observable<T>;
+
+	/**
+	 * A method to retrieve item(s) by ids
+	 * @param ids The IDs of the item(s)
+	 */
+	get(ids: string | string[]): Promise<T | undefined | T[]>;
 }
 
-export type StoreObservablePatchable<T> = StoreObservable<T> & StorePatchable<T>;
+export type ObservablePatchableStore<T> = ObservableStore<T> & PatchableStore<T>;
 
-export interface StorePatchable<T> {
+export interface PatchableStore<T> {
 	/**
 	 * A method that allows an partial object to be passed to patch the object
 	 * and receive the full object back as a resolution to a Promise

--- a/src/bases.d.ts
+++ b/src/bases.d.ts
@@ -6,7 +6,7 @@
  */
 
 import Promise from 'dojo-shim/Promise';
-import { Actionable, StoreObservablePatchable } from './abilities';
+import { Actionable, ObservablePatchableStore } from './abilities';
 import { EventCancelableObject, EventErrorObject, EventObject, EventTargettedObject, EventTypedObject, Handle } from './core';
 
 export interface Destroyable {
@@ -169,7 +169,7 @@ export interface StatefulMixin<S> {
 	/**
 	 * A readonly reference to the stateFrom provided to the widget on instantiation.
 	 */
-	readonly stateFrom: StoreObservablePatchable<S> | undefined;
+	readonly stateFrom: ObservablePatchableStore<S> | undefined;
 
 	/**
 	 * Set the state on the instance.
@@ -187,7 +187,7 @@ export interface StatefulMixin<S> {
 	 * @param observable An object which provides a `observe` and `patch` methods which allow `Stateful` to be able to
 	 *                   manage its state.
 	 */
-	observeState(id: string, observable: StoreObservablePatchable<S>): Handle;
+	observeState(id: string, observable: ObservablePatchableStore<S>): Handle;
 }
 
 /**
@@ -203,5 +203,5 @@ export interface StatefulOptions<S> extends EventedOptions {
 	/**
 	 * The `StoreObservablePatchable` used to back state.
 	 */
-	stateFrom?: StoreObservablePatchable<S>;
+	stateFrom?: ObservablePatchableStore<S>;
 }

--- a/tests/unit/abilities.ts
+++ b/tests/unit/abilities.ts
@@ -13,7 +13,8 @@ registerSuite({
 		assertType.isType(abilitiesTypes, 'Invalidatable', 'Invalidatable');
 		assertType.isType(abilitiesTypes, 'Renderable', 'Renderable');
 		assertType.isType(abilitiesTypes, 'RenderableParent', 'RenderableParent');
-		assertType.isType(abilitiesTypes, 'StoreObservable', 'StoreObservable<T>');
-		assertType.isType(abilitiesTypes, 'StorePatchable', 'StorePatchable<T>');
+		assertType.isType(abilitiesTypes, 'ObservableStore', 'ObservableStore<T>');
+		assertType.isType(abilitiesTypes, 'PatchableStore', 'PatchableStore<T>');
+		assertType.isType(abilitiesTypes, 'ObservablePatchableStore', 'ObservablePatchableStore<T>');
 	}
 });


### PR DESCRIPTION
**Type:** enhancement

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

* Expose get in `StoreObservable`(for now, will add more as necessary).
* Rename interfaces to be more consistent with other interfaces in this repo.

Resolves #37
