### PR TITLE
Add @dojo/cli common interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/glob": "~5.0.30",
     "@types/grunt": "~0.4.0",
     "@types/node": "~6.0.49",
+    "@types/yargs": "^8.0.2",
     "assertion-error": "^1.0.2",
     "grunt": "~1.0.1",
     "grunt-dojo2": "latest",

--- a/src/cli.d.ts
+++ b/src/cli.d.ts
@@ -61,10 +61,10 @@ export interface EjectOutput {
 /**
  * Inbuilt commands specify their name and group - installed commands have these props parsed out of their package dir name
  */
-export interface Command {
+export interface Command<T = any> {
 	description: string;
 	register(options: OptionsHelper, helper: Helper): void;
-	run(helper: Helper, args?: Argv): Promise<any>;
+	run(helper: Helper, args?: T): Promise<any>;
 	eject?(helper: Helper): EjectOutput;
 	name?: string;
 	group?: string;

--- a/src/cli.d.ts
+++ b/src/cli.d.ts
@@ -1,0 +1,77 @@
+import { Argv, Options } from 'yargs';
+
+export interface Config {
+	[key: string]: any;
+}
+
+export interface ConfigurationHelper {
+	set(config: Config): void;
+	get(): {};
+}
+
+export interface CommandHelper {
+	run(group: string, commandName?: string, args?: Argv): Promise<any>;
+	exists(group: string, commandName?: string): boolean;
+}
+
+export interface Helper {
+	yargs: Argv;
+	command: CommandHelper;
+	context: any;
+	configuration: ConfigurationHelper;
+}
+
+export type OptionsHelper = (key: string, options: Options) => void;
+
+export interface NpmPackage {
+	devDependencies?: {
+		[name: string]: string
+	};
+	dependencies?: {
+		[name: string]: string
+	};
+}
+
+export interface Alias {
+	name: string;
+	description?: string;
+	options: AliasOption[];
+}
+
+/**
+ * Represents one alias option. The option name is the full name of the option, and not the abbreviation. For
+ * example, if an option is (-w or --watch), you will specify "watch" as the option name.
+ */
+export interface AliasOption {
+	option: string;
+	value: string | boolean | number;
+}
+
+export interface FileCopyConfig {
+	path: string;
+	files: string[];
+}
+
+export interface EjectOutput {
+	npm?: NpmPackage;
+	copy?: FileCopyConfig;
+	hints?: string[];
+}
+
+/**
+ * Inbuilt commands specify their name and group - installed commands have these props parsed out of their package dir name
+ */
+export interface Command {
+	description: string;
+	register(options: OptionsHelper, helper: Helper): void;
+	run(helper: Helper, args?: Argv): Promise<any>;
+	eject?(helper: Helper): EjectOutput;
+	name?: string;
+	group?: string;
+	alias?: Alias[] | Alias;
+}
+
+export interface CommandError {
+	exitCode?: number;
+	message: string;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
 			"dom",
 			"es5",
 			"es2015.iterable",
+			"es2015.promise",
 			"es2015.symbol",
 			"es2015.symbol.wellknown"
 		],


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds the common `@dojo/cli` interfaces as part of a migration to @types/yargs and removing cyclical dependencies.

Refs: https://github.com/dojo/cli/issues/119
