### PR TITLE
Removing export assignment

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import * as cli from './cli';
 import * as loader from './loader';
 
-export = {
+export {
 	cli,
 	loader
 };


### PR DESCRIPTION
Removing export assignment as it is not compatible when compiled with `esnext`.